### PR TITLE
Fixed Array1D constructor missing

### DIFF
--- a/TNT/tnt_array1d.h
+++ b/TNT/tnt_array1d.h
@@ -62,7 +62,8 @@ class Array1D
 	explicit Array1D(int n);
 	         Array1D(int n, const T &a);
 	         Array1D(int n,  T *a);
-    inline   Array1D(const Array1D &A);
+           Array1D(int n, const T *a);
+  inline   Array1D(const Array1D &A);
 	inline   operator T*();
 	inline   operator const T*();
 	inline   Array1D & operator=(const T &a);
@@ -124,6 +125,14 @@ Array1D<T>::Array1D(int n, T *a) : v_(a), n_(n) , data_(v_.begin())
 {
 #ifdef TNT_DEBUG
 	std::cout << "Created Array1D(int n, T* a) \n";
+#endif
+}
+
+template <class T>
+Array1D<T>::Array1D(int n, const T *a) : v_(a), n_(n), data_(v_.begin())
+{
+#ifndef TNT_DEBUG
+  std::cout << "Created Array1D(int n, const T* a) \n";
 #endif
 }
 


### PR DESCRIPTION
The `TNT::Array1D(int n,  T *a);` constructor takes arguments by non-const reference, but in `tnt_sparse_matrix_csr.h` it tries to use a member initialisation list of temporary objects, as was happening here:
```cpp
template <class T>
Sparse_Matrix_CompRow<T>::Sparse_Matrix_CompRow(int M, int N, int nz,
	const T *val, const int *r, const int *c) : val_(nz,val), 
		rowptr_(M, r), colind_(nz, c), dim1_(M), dim2_(N) {}   // <--- not allowed!
```
Temporary objects cannot bind to non-const references. (https://stackoverflow.com/questions/8101489/c-no-matching-constructor-for-initialization-of-compiler-error), and you get this error when trying to compile with clang (I don't know why other compilers don't pick it up?):

```
/home/dav/Devel/HAIL-CAESAR/include/TNT/tnt_sparse_matrix_csr.h:97:3: error: no matching constructor for initialization of 'Array1D<int>' [clang-diagnostic-error]
                rowptr_(M, r), colind_(nz, c), dim1_(M), dim2_(N) {}
                ^          ~
                           *
include/TNT/tnt_array1d.h:63:11: note: candidate constructor not viable: no known conversion from 'const int *' to 'const int' for 2nd argument; dereference the argument with *
                 Array1D(int n, const T &a);
                 ^
include/TNT/tnt_array1d.h:64:11: note: candidate constructor not viable: 2nd argument ('const int *') would lose const qualifier
                 Array1D(int n,  T *a);
```

So the solution is just to add another constructor for `TNT::Array1D` that takes a const reference. I think...  

Clang does not complain now.